### PR TITLE
Add sealed hierarchy analysis.

### DIFF
--- a/tasty-mima/src/test/scala/tastymima/AnalyzeSuite.scala
+++ b/tasty-mima/src/test/scala/tastymima/AnalyzeSuite.scala
@@ -138,7 +138,12 @@ class AnalyzeSuite extends munit.FunSuite:
       PM.IncompatibleTypeChange("testlib.membertypechanges.MemberTypeChanges.methodSameSigOtherResultType"),
       // Side effects of changing the type of a var
       PM.MissingTermMember("testlib.membertypechanges.MemberTypeChanges.varSubType_="),
-      PM.MissingTermMember("testlib.membertypechanges.MemberTypeChanges.varOtherType_=")
+      PM.MissingTermMember("testlib.membertypechanges.MemberTypeChanges.varOtherType_="),
+      // Members in a (partially) sealed hierarchy
+      PM.IncompatibleTypeChange("testlib.membertypechanges.SealedHierarchy.defOpenNoOverride"),
+      PM.IncompatibleTypeChange("testlib.membertypechanges.SealedHierarchy.defOpenWithOverride"),
+      PM.IncompatibleTypeChange("testlib.membertypechanges.SealedHierarchy.defSometimesFinal"),
+      PM.IncompatibleTypeChange("testlib.membertypechanges.SealedHierarchy.accessibleProtected")
     )
   }
 

--- a/test-lib-v1/src/main/scala/testlib/memberkindchanges/MemberKindChanges.scala
+++ b/test-lib-v1/src/main/scala/testlib/memberkindchanges/MemberKindChanges.scala
@@ -1,6 +1,6 @@
 package testlib.memberkindchanges
 
-class MemberKindChanges:
+final class MemberKindChanges:
   val valToVal: Int = 1
   val valToVar: Int = 1
   val valToModule: Any = Nil

--- a/test-lib-v1/src/main/scala/testlib/membertypechanges/SealedHierarchy.scala
+++ b/test-lib-v1/src/main/scala/testlib/membertypechanges/SealedHierarchy.scala
@@ -1,0 +1,34 @@
+package testlib.membertypechanges
+
+sealed abstract class SealedHierarchy:
+  def defOpenNoOverride: AnyVal = 1
+  def defOpenWithOverride: AnyVal = 1
+  final def defFinal: AnyVal = 1
+  def defSometimesFinal: AnyVal = 1
+  def defAllOverridesFinal: AnyVal = 1
+
+  protected def accessibleProtected: Int = 1
+end SealedHierarchy
+
+final class FinalSubclass extends SealedHierarchy:
+  protected def inaccessibleBecauseFinalProtected: Int = 1
+
+sealed class FullySealedSubclass extends SealedHierarchy:
+  override def defOpenWithOverride: AnyVal = 1
+  override final def defAllOverridesFinal: AnyVal = 1
+
+  protected def inaccessibleBecauseSealedProtected: Int = 1
+end FullySealedSubclass
+
+final class FullySealedSubSubclass extends FullySealedSubclass
+
+sealed class SealedSubclass extends SealedHierarchy:
+  override final def defAllOverridesFinal: AnyVal = 1
+
+class OpenSubSubclass1 extends SealedSubclass:
+  override final def defOpenWithOverride: AnyVal = 1
+
+open class OpenSubSubclass2 extends SealedSubclass:
+  override final def defSometimesFinal: AnyVal = 1
+
+final class FinalSubSubclass extends SealedSubclass

--- a/test-lib-v2/src/main/scala/testlib/memberkindchanges/MemberKindChanges.scala
+++ b/test-lib-v2/src/main/scala/testlib/memberkindchanges/MemberKindChanges.scala
@@ -1,6 +1,6 @@
 package testlib.memberkindchanges
 
-class MemberKindChanges:
+final class MemberKindChanges:
   val valToVal: Int = 1
   var valToVar: Int = 1
   object valToModule

--- a/test-lib-v2/src/main/scala/testlib/membertypechanges/SealedHierarchy.scala
+++ b/test-lib-v2/src/main/scala/testlib/membertypechanges/SealedHierarchy.scala
@@ -1,0 +1,34 @@
+package testlib.membertypechanges
+
+sealed abstract class SealedHierarchy:
+  def defOpenNoOverride: Int = 1
+  def defOpenWithOverride: Int = 1
+  final def defFinal: Int = 1
+  def defSometimesFinal: Int = 1
+  def defAllOverridesFinal: Int = 1
+
+  protected def accessibleProtected: String = "foo"
+end SealedHierarchy
+
+final class FinalSubclass extends SealedHierarchy:
+  protected def inaccessibleBecauseFinalProtected: String = "foo"
+
+sealed class FullySealedSubclass extends SealedHierarchy:
+  override def defOpenWithOverride: Int = 1
+  override final def defAllOverridesFinal: Int = 1
+
+  protected def inaccessibleBecauseSealedProtected: String = "foo"
+end FullySealedSubclass
+
+final class FullySealedSubSubclass extends FullySealedSubclass
+
+sealed class SealedSubclass extends SealedHierarchy:
+  override final def defAllOverridesFinal: Int = 1
+
+class OpenSubSubclass1 extends SealedSubclass:
+  override final def defOpenWithOverride: Int = 1
+
+open class OpenSubSubclass2 extends SealedSubclass:
+  override final def defSometimesFinal: Int = 1
+
+final class FinalSubSubclass extends SealedSubclass


### PR DESCRIPTION
In general, members can be overridden outside the library. When that is the case, they must preserve an *equivalent* result type.

Members that cannot be overridden outside the library can evolve with a *subtype* in future versions. We can decide that property with an analysis of final members and sealed class hierarchies.