### PR TITLE
Upgrade to Scala 3.2.2 and tasty-query 0.5.7.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ val rtJarOpt = taskKey[Option[String]]("Path to rt.jar if it exists")
 val javalibEntry = taskKey[String]("Path to rt.jar or \"jrt:/\"")
 
 inThisBuild(Def.settings(
-  crossScalaVersions := Seq("3.1.0"),
+  crossScalaVersions := Seq("3.2.2"),
   scalaVersion := crossScalaVersions.value.head,
 
   scalacOptions ++= Seq(
@@ -74,7 +74,7 @@ lazy val tastyMiMa =
       testFrameworks += new TestFramework("munit.Framework")
     )
     .settings(
-      libraryDependencies += "ch.epfl.scala" %% "tasty-query" % "0.5.6",
+      libraryDependencies += "ch.epfl.scala" %% "tasty-query" % "0.5.7",
 
       Test / rtJarOpt := {
         for (bootClasspath <- Option(System.getProperty("sun.boot.class.path"))) yield {

--- a/tasty-mima/src/main/scala/tastymima/Analyzer.scala
+++ b/tasty-mima/src/main/scala/tastymima/Analyzer.scala
@@ -19,11 +19,11 @@ private[tastymima] final class Analyzer(val config: Config, val oldCtx: Context,
   import Analyzer.*
 
   private val problemFilters: List[ProblemMatcher] =
-    import scala.collection.JavaConverters.*
+    import scala.jdk.CollectionConverters.*
     config.getProblemFilters().nn.asScala.toList
 
   private val artifactPrivatePackagePaths: List[List[SimpleName]] =
-    import scala.collection.JavaConverters.*
+    import scala.jdk.CollectionConverters.*
     for stringPath <- config.getArtifactPrivatePackages().nn.asScala.toList
     yield stringPath.split('.').toList.map(termName(_))
 

--- a/tasty-mima/src/main/scala/tastymima/TastyMiMa.scala
+++ b/tasty-mima/src/main/scala/tastymima/TastyMiMa.scala
@@ -56,7 +56,7 @@ final class TastyMiMa(config: Config) extends ITastyMiMa:
     newClasspath: JList[Path],
     newClasspathEntry: Path
   ): JList[IProblem] =
-    import scala.collection.JavaConverters.*
+    import scala.jdk.CollectionConverters.*
 
     val problems =
       analyze(oldClasspath.asScala.toList, oldClasspathEntry, newClasspath.asScala.toList, newClasspathEntry)

--- a/tasty-mima/src/test/scala/tastymima/JavaAPISuite.scala
+++ b/tasty-mima/src/test/scala/tastymima/JavaAPISuite.scala
@@ -7,7 +7,7 @@ import tastymima.intf.{Config, ProblemKind}
 
 class JavaAPISuite extends munit.FunSuite:
   def analyzeTestLib(tastyMiMa: intf.TastyMiMa): List[intf.Problem] =
-    import scala.collection.JavaConverters.*
+    import scala.jdk.CollectionConverters.*
     import TestClasspaths.*
 
     val javaProblems =


### PR DESCRIPTION
tasty-query 0.5.7 now supports TASTy failes generated by Scala 3.2.x, but also requires to be used from Scala 3.2.x, so they must be upgraded at the same time.