### PR TITLE
Handle polymorphic opaque type aliases.

### DIFF
--- a/tasty-mima/src/test/scala/tastymima/AnalyzeSuite.scala
+++ b/tasty-mima/src/test/scala/tastymima/AnalyzeSuite.scala
@@ -199,7 +199,17 @@ class AnalyzeSuite extends munit.FunSuite:
       PM(PK.IncompatibleTypeChange, "testlib.membertypechanges.TypeMemberTypeChanges.AbstractTypeOtherBounds"),
       // Opaque type alias
       PM(PK.IncompatibleTypeChange, "testlib.membertypechanges.TypeMemberTypeChanges.OpaqueTypeAliasOtherBounds"),
-      PM(PK.IncompatibleTypeChange, "testlib.membertypechanges.TypeMemberTypeChanges.OpaqueTypeAliasOtherErasedAlias")
+      PM(PK.IncompatibleTypeChange, "testlib.membertypechanges.TypeMemberTypeChanges.OpaqueTypeAliasOtherErasedAlias"),
+      // Polymorphic type alias
+      PM(PK.IncompatibleTypeChange, "testlib.membertypechanges.TypeMemberTypeChanges.PolyOpaqueTypeAliasOtherBounds"),
+      PM(
+        PK.IncompatibleTypeChange,
+        "testlib.membertypechanges.TypeMemberTypeChanges.PolyOpaqueTypeAliasSameErasedAlias"
+      ),
+      PM(
+        PK.IncompatibleTypeChange,
+        "testlib.membertypechanges.TypeMemberTypeChanges.PolyOpaqueTypeAliasOtherErasedAlias"
+      )
     )
   }
 

--- a/test-lib-v1/src/main/scala/testlib/membertypechanges/TypeMemberTypeChanges.scala
+++ b/test-lib-v1/src/main/scala/testlib/membertypechanges/TypeMemberTypeChanges.scala
@@ -14,4 +14,10 @@ final class TypeMemberTypeChanges:
   opaque type OpaqueTypeAliasOtherBounds >: List[Nothing] <: Seq[AnyVal] = List[Int]
   opaque type OpaqueTypeAliasSameErasedAlias >: List[Nothing] <: Seq[AnyVal] = List[Int]
   opaque type OpaqueTypeAliasOtherErasedAlias >: List[Nothing] <: Seq[AnyVal] = List[Int]
+
+  opaque type PolyOpaqueTypeAliasSameAll[A] >: List[Nothing] <: Seq[AnyVal] = List[Int]
+  opaque type PolyOpaqueTypeAliasSubBounds[A] >: List[Nothing] <: Seq[AnyVal] = List[Int]
+  opaque type PolyOpaqueTypeAliasOtherBounds[A] >: List[Nothing] <: Seq[AnyVal] = List[Int]
+  opaque type PolyOpaqueTypeAliasSameErasedAlias[A] >: List[Nothing] <: Seq[AnyVal] = List[Int]
+  opaque type PolyOpaqueTypeAliasOtherErasedAlias[A] >: List[Nothing] <: Seq[AnyVal] = List[Int]
 end TypeMemberTypeChanges

--- a/test-lib-v2/src/main/scala/testlib/membertypechanges/TypeMemberTypeChanges.scala
+++ b/test-lib-v2/src/main/scala/testlib/membertypechanges/TypeMemberTypeChanges.scala
@@ -14,4 +14,10 @@ final class TypeMemberTypeChanges:
   opaque type OpaqueTypeAliasOtherBounds >: List[Nothing] <: java.io.Serializable = List[Int]
   opaque type OpaqueTypeAliasSameErasedAlias >: List[Nothing] <: Seq[AnyVal] = List[AnyVal]
   opaque type OpaqueTypeAliasOtherErasedAlias >: List[Nothing] <: Seq[AnyVal] = Seq[Int]
+
+  opaque type PolyOpaqueTypeAliasSameAll[A] >: List[Nothing] <: Seq[AnyVal] = List[Int]
+  opaque type PolyOpaqueTypeAliasSubBounds[A] >: List[Int] <: Seq[Int] = List[Int]
+  opaque type PolyOpaqueTypeAliasOtherBounds[A] >: List[Nothing] <: java.io.Serializable = List[Int]
+  opaque type PolyOpaqueTypeAliasSameErasedAlias[A] >: List[Nothing] <: Seq[AnyVal] = List[AnyVal]
+  opaque type PolyOpaqueTypeAliasOtherErasedAlias[A] >: List[Nothing] <: Seq[AnyVal] = Seq[Int]
 end TypeMemberTypeChanges


### PR DESCRIPTION
We cannot erase a `TypeLambda`, since only monomorphic types have a meaningful erasure. In theory, we should guarantee the same erasure for *all* possible instantiation of the type parameters. That being basically impossible, we demand that the `TypeLambda`s be equivalent instead.