### PR TITLE
Report class type parameter name changes as problems.

### DIFF
--- a/tasty-mima-interface/src/main/java/tastymima/intf/ProblemKind.java
+++ b/tasty-mima-interface/src/main/java/tastymima/intf/ProblemKind.java
@@ -12,6 +12,7 @@ public enum ProblemKind {
   AbstractClass,
   FinalMember,
   TypeArgumentCountMismatch,
+  IncompatibleNameChange,
   IncompatibleTypeChange,
   NewAbstractMember,
   InternalError;

--- a/tasty-mima/src/main/scala/tastymima/Analyzer.scala
+++ b/tasty-mima/src/main/scala/tastymima/Analyzer.scala
@@ -144,6 +144,8 @@ private[tastymima] final class Analyzer(val config: Config, val oldCtx: Context,
   end checkOpenLevel
 
   private def analyzeClassTypeParam(oldSym: ClassTypeParamSymbol, newSym: ClassTypeParamSymbol): Unit =
+    if oldSym.name != newSym.name then reportProblem(ProblemKind.IncompatibleNameChange, oldSym)
+
     val oldBounds = oldSym.bounds(using oldCtx)
     val translatedOldBounds = translateTypeBounds(oldBounds)
     val newBounds = newSym.bounds(using newCtx)

--- a/tasty-mima/src/test/scala/tastymima/AnalyzeSuite.scala
+++ b/tasty-mima/src/test/scala/tastymima/AnalyzeSuite.scala
@@ -229,6 +229,7 @@ class AnalyzeSuite extends munit.FunSuite:
 
     assertProblems(problems)(
       // From ClassTypeParams.scala
+      PM(PK.IncompatibleNameChange, "testlib.classtypeparams.ClassTypeParams.A"),
       PM(PK.IncompatibleTypeChange, "testlib.classtypeparams.ClassTypeParams.a3"),
       PM(PK.IncompatibleTypeChange, "testlib.classtypeparams.ClassTypeParams.b3"),
       PM(PK.IncompatibleTypeChange, "testlib.classtypeparams.ClassTypeParams.Inner.c4"),
@@ -236,7 +237,9 @@ class AnalyzeSuite extends munit.FunSuite:
       PM(PK.TypeArgumentCountMismatch, "testlib.classtypeparams.ClassTypeParams.ArgCountMismatch"),
       // From ClassTypeParamBounds.scala
       PM(PK.IncompatibleTypeChange, "testlib.classtypeparams.ClassTypeParamBounds.B"),
-      PM(PK.IncompatibleTypeChange, "testlib.classtypeparams.ClassTypeParamBounds.C")
+      PM(PK.IncompatibleTypeChange, "testlib.classtypeparams.ClassTypeParamBounds.C"),
+      PM(PK.IncompatibleNameChange, "testlib.classtypeparams.ClassTypeParamBounds.A"),
+      PM(PK.IncompatibleNameChange, "testlib.classtypeparams.ClassTypeParamBounds.B")
     )
   }
 

--- a/test-lib-v2/src/main/scala/testlib/classtypeparams/ClassTypeParamBounds.scala
+++ b/test-lib-v2/src/main/scala/testlib/classtypeparams/ClassTypeParamBounds.scala
@@ -1,3 +1,3 @@
 package testlib.classtypeparams
 
-final class ClassTypeParamBounds[X <: Any, Y >: Nothing <: AnyVal, Z <: Y]
+final class ClassTypeParamBounds[X <: Any, Y >: Nothing <: AnyVal, C <: Y]


### PR DESCRIPTION
Class type parameter names can be referred to from separate TASTy files in the presence of capture conversion. Therefore, the names are unfortunately part of the public TASTy API.