### PR TITLE
Add the expected signature for missing term member problems.

### DIFF
--- a/tasty-mima/src/main/scala/tastymima/Analyzer.scala
+++ b/tasty-mima/src/main/scala/tastymima/Analyzer.scala
@@ -203,7 +203,7 @@ private[tastymima] final class Analyzer(val config: Config, val oldCtx: Context,
         case oldDecl: TermSymbol =>
           lookupCorrespondingTermMember(oldCtx, oldDecl, newCtx, newClass) match
             case None =>
-              reportProblem(ProblemKind.MissingTermMember, oldDecl)
+              reportProblem(ProblemKind.MissingTermMember, oldDecl, oldDecl.signature(using oldCtx))
             case Some(newDecl) =>
               analyzeTermMember(oldDecl, oldIsOverridable, newThisType, newDecl)
   end analyzeMemberOfClass
@@ -351,7 +351,7 @@ private[tastymima] final class Analyzer(val config: Config, val oldCtx: Context,
         }
         if !oldIsAbstractEverywhere then
           // Then it is a problem
-          reportProblem(ProblemKind.NewAbstractMember, newDecl)
+          reportProblem(ProblemKind.NewAbstractMember, newDecl, newDecl.signature(using newCtx))
   end checkNewMaybeAbstractTermMember
 
   private def translateType(oldType: Type): Type =

--- a/tasty-mima/src/main/scala/tastymima/Problem.scala
+++ b/tasty-mima/src/main/scala/tastymima/Problem.scala
@@ -2,6 +2,7 @@ package tastymima
 
 import tastyquery.Modifiers.*
 import tastyquery.Names.*
+import tastyquery.Signatures.*
 import tastyquery.Types.*
 
 import tastymima.intf.{ProblemKind, Problem as IProblem}
@@ -21,10 +22,20 @@ final class Problem(val kind: ProblemKind, val path: List[Name], val details: Ma
   def getPathString(): String = pathString
 
   override def getDescription(): String | Null =
-    val superDesc = super.getDescription()
+    (kind, details) match
+      // Better sentence structure than putting `details` at the end for some combinations
 
-    if details == () then superDesc
-    else s"$superDesc: ${detailsString(details)}"
+      case (ProblemKind.MissingTermMember, details: Signature) =>
+        s"The member ${getPathString()} with signature $details does not have a correspondant in current version"
+      case (ProblemKind.NewAbstractMember, details: Signature) =>
+        s"The member ${getPathString()} with signature $details "
+          + "was concrete or did not exist but is abstract in current version"
+
+      case _ =>
+        val superDesc = super.getDescription()
+
+        if details == () then superDesc
+        else s"$superDesc: ${detailsString(details)}"
   end getDescription
 
   private def detailsString(details: Matchable): String = details match


### PR DESCRIPTION
This is for `MissingTermMember` and `NewAbstractMember`. It can help identify problems in the presence of overloads.