### PR TITLE
Upgrade to Scala 3.4.0 and tasty-query 1.3.0.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -28,7 +28,7 @@ inThisBuild(Def.settings(
     Developer("bishabosha", "Jamie Thompson", "bishbashboshjt@gmail.com", url("https://github.com/bishabosha")),
   ),
 
-  versionPolicyIntention := Compatibility.BinaryAndSourceCompatible,
+  versionPolicyIntention := Compatibility.BinaryCompatible,
   // Ignore dependencies to internal modules whose version is like `1.2.3+4...` (see https://github.com/scalacenter/sbt-version-policy#how-to-integrate-with-sbt-dynver)
   versionPolicyIgnoredInternalDependencyVersions := Some("^\\d+\\.\\d+\\.\\d+\\+\\d+".r),
 ))

--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ val rtJarOpt = taskKey[Option[String]]("Path to rt.jar if it exists")
 val javalibEntry = taskKey[String]("Path to rt.jar or \"jrt:/\"")
 
 inThisBuild(Def.settings(
-  crossScalaVersions := Seq("3.3.1"),
+  crossScalaVersions := Seq("3.4.0"),
   scalaVersion := crossScalaVersions.value.head,
 
   scalacOptions ++= Seq(
@@ -31,6 +31,9 @@ inThisBuild(Def.settings(
   versionPolicyIntention := Compatibility.BinaryCompatible,
   // Ignore dependencies to internal modules whose version is like `1.2.3+4...` (see https://github.com/scalacenter/sbt-version-policy#how-to-integrate-with-sbt-dynver)
   versionPolicyIgnoredInternalDependencyVersions := Some("^\\d+\\.\\d+\\.\\d+\\+\\d+".r),
+
+  // Temporary until we upgrade to an sbt-tasty-mima that supports Scala 3.4.x out of the box
+  tastyMiMaTastyQueryVersionOverride := Some("1.3.0"),
 ))
 
 val commonSettings = Seq(
@@ -94,7 +97,7 @@ lazy val tastyMiMa =
       testFrameworks += new TestFramework("munit.Framework")
     )
     .settings(
-      libraryDependencies += "ch.epfl.scala" %% "tasty-query" % "1.2.0",
+      libraryDependencies += "ch.epfl.scala" %% "tasty-query" % "1.3.0",
 
       Test / rtJarOpt := {
         for (bootClasspath <- Option(System.getProperty("sun.boot.class.path"))) yield {


### PR DESCRIPTION
This adds support for checking codebases written in Scala 3.4.x.