### PR TITLE
Upgrade to Scala 3.7.1 and tasty-query 1.6.1.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ val rtJarOpt = taskKey[Option[String]]("Path to rt.jar if it exists")
 val javalibEntry = taskKey[String]("Path to rt.jar or \"jrt:/\"")
 
 inThisBuild(Def.settings(
-  crossScalaVersions := Seq("3.5.0"),
+  crossScalaVersions := Seq("3.7.1"),
   scalaVersion := crossScalaVersions.value.head,
 
   scalacOptions ++= Seq(
@@ -31,6 +31,9 @@ inThisBuild(Def.settings(
   versionPolicyIntention := Compatibility.BinaryCompatible,
   // Ignore dependencies to internal modules whose version is like `1.2.3+4...` (see https://github.com/scalacenter/sbt-version-policy#how-to-integrate-with-sbt-dynver)
   versionPolicyIgnoredInternalDependencyVersions := Some("^\\d+\\.\\d+\\.\\d+\\+\\d+".r),
+
+  // Temporary until we upgrade to an sbt-tasty-mima that supports Scala 3.7.x out of the box
+  tastyMiMaTastyQueryVersionOverride := Some("1.6.1"),
 ))
 
 val commonSettings = Seq(
@@ -94,7 +97,7 @@ lazy val tastyMiMa =
       testFrameworks += new TestFramework("munit.Framework")
     )
     .settings(
-      libraryDependencies += "ch.epfl.scala" %% "tasty-query" % "1.4.0",
+      libraryDependencies += "ch.epfl.scala" %% "tasty-query" % "1.6.1",
 
       Test / rtJarOpt := {
         for (bootClasspath <- Option(System.getProperty("sun.boot.class.path"))) yield {

--- a/tasty-mima/src/main/scala/tastymima/Analyzer.scala
+++ b/tasty-mima/src/main/scala/tastymima/Analyzer.scala
@@ -406,7 +406,7 @@ private[tastymima] final class Analyzer(val config: Config, val oldCtx: Context,
       case _ => false
   end isValidVisibilityChange
 
-  private val openBoundaryMemoized = mutable.AnyRefMap.empty[ClassSymbol, Set[ClassSymbol]]
+  private val openBoundaryMemoized = mutable.HashMap.empty[ClassSymbol, Set[ClassSymbol]]
 
   /** Returns the "open boundary" of a class.
     *


### PR DESCRIPTION
This adds support for checking codebases written in Scala 3.7.x.